### PR TITLE
fix(README): syntax & typo correction

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -169,10 +169,10 @@ require('reticle').setup {
     },
 
     -- Disable the cursorline and cursorcolumn in insert mode. Default is true
-    disable_in_insert = false
+    disable_in_insert = false,
 
     -- By default, nvim highlights the cursorline number only when the cursorline setting is
-    -- switched on. When enabeling the following setting, the cursorline number
+    -- switched on. When enabling the following setting, the cursorline number
     -- of every window is always highlighted, regardless of the setting
     always_highlight_number = true,
 


### PR DESCRIPTION
The config example cannot be used as is because of a comma missing. This PR fixes this + a little typo bonus